### PR TITLE
Use topo module for sorting property dependencies - closes #1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test": "lab -cvLS -T ./node_modules/lab-babel"
   },
   "dependencies": {
-    "lodash": "^3.8.0"
+    "lodash": "^3.8.0",
+    "topo": "^1.0.2"
   },
   "devDependencies": {
     "babel-core": "^5.2.17",

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -5,22 +5,19 @@ const Topo = require('topo');
 
 function normalizeNodes(attributes){
   return _.map(attributes, function(attr, key){
-    let node;
     if(!_.isPlainObject(attr)){
-      node = {
+      return {
         key: key,
         group: key
       };
     } else {
-      node = {
+      return {
         key: key,
         group: attr.group || key,
         before: attr.before,
         after: attr.after
       };
     }
-
-    return node;
   });
 }
 

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const _ = require('lodash');
+const Topo = require('topo');
+
+function normalizeNodes(attributes){
+  return _.map(attributes, function(attr, key){
+    let node;
+    if(!_.isPlainObject(attr)){
+      node = {
+        key: key,
+        group: key
+      };
+    } else {
+      node = {
+        key: key,
+        group: attr.group || key,
+        before: attr.before,
+        after: attr.after
+      };
+    }
+
+    return node;
+  });
+}
+
+function dependencies(attributes){
+  const topo = new Topo();
+
+  const nodes = normalizeNodes(attributes);
+
+  _.forEach(nodes, function(node){
+    topo.add(node.key, node);
+  });
+
+  return topo.nodes;
+}
+
+module.exports = dependencies;

--- a/src/factory.js
+++ b/src/factory.js
@@ -3,10 +3,19 @@
 const _ = require('lodash');
 
 const resolve = require('./resolve');
+const dependencies = require('./dependencies');
+
+function reducer(result, propertyKey){
+  const attribute = result[propertyKey];
+  result[propertyKey] = resolve(attribute, propertyKey, result);
+  return result;
+}
 
 class Factory {
   constructor(schema){
-    const attributes = resolve(schema.attributes);
+    const attrs = _.clone(schema.attributes);
+    const order = dependencies(attrs);
+    const attributes = _.reduce(order, reducer, attrs);
 
     _.assign(this, attributes);
   }

--- a/src/factory.js
+++ b/src/factory.js
@@ -5,17 +5,11 @@ const _ = require('lodash');
 const resolve = require('./resolve');
 const dependencies = require('./dependencies');
 
-function reducer(result, propertyKey){
-  const attribute = result[propertyKey];
-  result[propertyKey] = resolve(attribute, propertyKey, result);
-  return result;
-}
-
 class Factory {
   constructor(schema){
     const attrs = _.clone(schema.attributes);
     const order = dependencies(attrs);
-    const attributes = _.reduce(order, reducer, attrs);
+    const attributes = _.reduce(order, resolve, attrs);
 
     _.assign(this, attributes);
   }

--- a/src/resolve.js
+++ b/src/resolve.js
@@ -2,9 +2,8 @@
 
 const _ = require('lodash');
 
-function normalizeNode(attribute, key, ctx){
+function normalizeNode(attribute, ctx){
   const base = {
-    key: key,
     ctx: ctx
   };
 
@@ -15,15 +14,14 @@ function normalizeNode(attribute, key, ctx){
   }
 }
 
-function resolveFunctions({ value, ctx, key }){
+function resolveFunctions({ value, ctx }){
   return {
     ctx: ctx,
-    key: key,
     value: _.isFunction(value) ? value.call(ctx) : value
   };
 }
 
-function resolveTemplates({ ctx, value }){
+function resolveTemplates({ value, ctx }){
   if(_.isString(value)){
     return _.template(value)(ctx);
   }
@@ -31,6 +29,12 @@ function resolveTemplates({ ctx, value }){
   return value;
 }
 
-const resolve = _.flow(normalizeNode, resolveFunctions, resolveTemplates);
+const resolvers = _.flow(normalizeNode, resolveFunctions, resolveTemplates);
+
+function resolve(result, propertyKey){
+  const attribute = result[propertyKey];
+  result[propertyKey] = resolvers(attribute, result);
+  return result;
+}
 
 module.exports = resolve;

--- a/test/factories/user.js
+++ b/test/factories/user.js
@@ -12,11 +12,11 @@ const User = {
     username: internet.userName,
     firstName: {
       group: 'name',
-      default: name.firstName()
+      default: name.firstName
     },
     lastName: {
       group: 'name',
-      default: name.lastName()
+      default: name.lastName
     },
     fullName: {
       after: 'name',

--- a/test/factories/user.js
+++ b/test/factories/user.js
@@ -4,6 +4,10 @@ const { internet, name } = require('faker');
 
 const User = {
   attributes: {
+    combined: {
+      after: ['id', 'password', 'fullName'],
+      default: '<%= id + password + fullName %>'
+    },
     id: 1,
     password: {
       after: 'username',

--- a/test/factories/user.js
+++ b/test/factories/user.js
@@ -11,12 +11,18 @@ const User = {
     },
     username: internet.userName,
     firstName: {
-      group: 'first',
+      group: 'name',
       default: name.firstName()
     },
     lastName: {
-      after: 'first',
+      group: 'name',
       default: name.lastName()
+    },
+    fullName: {
+      after: 'name',
+      default: function(){
+        return `${this.firstName} ${this.lastName}`;
+      }
     }
   }
 };

--- a/test/factories/user.js
+++ b/test/factories/user.js
@@ -1,12 +1,23 @@
 'use strict';
 
-const { internet } = require('faker');
+const { internet, name } = require('faker');
 
 const User = {
   attributes: {
     id: 1,
+    password: {
+      after: 'username',
+      default: '<%= username + "Password" %>'
+    },
     username: internet.userName,
-    password: '<%= username + "Password" %>'
+    firstName: {
+      group: 'first',
+      default: name.firstName()
+    },
+    lastName: {
+      after: 'first',
+      default: name.lastName()
+    }
   }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -48,4 +48,12 @@ experiment('schema', () => {
     expect(fullName).to.contain(lastName);
     done();
   });
+
+  test('after allows array of dependencies', (done) => {
+    const { id, password, fullName, combined } = schema(factories.user);
+    expect(combined).to.contain('' + id);
+    expect(combined).to.contain(password);
+    expect(combined).to.contain(fullName);
+    done();
+  });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -41,4 +41,11 @@ experiment('schema', () => {
     expect(password).to.contain('Password');
     done();
   });
+
+  test('groups based on group property', (done) => {
+    const { firstName, lastName, fullName } = schema(factories.user);
+    expect(fullName).to.contain(firstName);
+    expect(fullName).to.contain(lastName);
+    done();
+  });
 });


### PR DESCRIPTION
#### What's this PR do?

Adds property dependency logic.  The syntax is as follows:

``` js
{
    attributes: {
        firstName: faker.firstName,
        lastName: faker.lastName,
        fullName: {
            after: ['firstName', 'lastName'],
            default: '<%= firstName + " " + lastName %>'
        }
    }
}
```

This example can also be written as below because the order of `firstName` and `lastName` doesn't matter.

``` js
{
    attributes: {
        firstName: {
            // properties can be grouped by a string name
            group: 'name',
            default: faker.firstName
        },
        lastName: {
            group: 'name',
            default: faker.lastName
        },
        fullName: {
            // gets sorted after all properties in the `name` group
            after: 'name',
            default: '<%= firstName + " " + lastName %>'
        }
    }
}
```

This will also support a `before` property:

``` js
{
    attributes: {
        firstName: {
            before: 'fullName',
            default: faker.firstName
        },
        lastName: {
            before: 'fullName',
            default: faker.lastName
        },
        fullName: '<%= firstName + " " + lastName %>'
    }
}
```
#### How should this be tested by the reviewer?

Verify the tests are correct and pass.  Attempt to write a schema that has complex dependency tree, see if the result is correct.
#### Is any other information necessary to understand this?

This uses the `topo` module by the Hapi team and is used internally to Hapi, so it should be quite solid.
#### What are the relevant tickets? (Please add `closes`, `refs`, etc)

Closes #1 
